### PR TITLE
Add to_datetime function

### DIFF
--- a/lib/dateless_time.rb
+++ b/lib/dateless_time.rb
@@ -42,6 +42,13 @@ class DatelessTime
     nil
   end
 
+  def to_datetime(base = DateTime.now)
+    args = [base.year, base.month, base.day, @hours, @minutes, @seconds]
+    args << base.utc_offset if base.is_a?(DateTime)
+    @time_value = DateTime.new(*args)
+  rescue
+    nil
+  end
 
   def to_s
     @string_value ||= sprintf(SPRINTF_FORMAT, @hours, @minutes, @seconds)

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -1,5 +1,10 @@
 require 'test_helper'
 
+class DateTime
+  def utc_offset  #patch DateTime
+    self.to_time.utc_offset 
+  end
+end
 class QueryTest < Minitest::Test
 
   def setup
@@ -7,6 +12,9 @@ class QueryTest < Minitest::Test
   end
 
 
+=begin
+Test to_time
+=end
 
   def test_to_time_without_base
     @to_time = @dl_time.to_time
@@ -52,6 +60,56 @@ class QueryTest < Minitest::Test
     assert_equal Time.new(1990, 11, 10, 13, 37, 42), @to_time
   end
 
+=begin
+Test to_datetime
+=end
+
+  def test_to_datetime_without_base
+    @to_datetime = @dl_time.to_datetime
+    now = DateTime.now
+    expected = DateTime.new(now.year, now.month, now.day, 13, 37, 42, now.utc_offset)
+
+    assert_equal DateTime, @to_datetime.class
+    assert_equal expected, @to_datetime
+  end
+
+
+  def test_to_datetime_with_time_base
+    base = DateTime.new(1990, 11, 10, 12, 13, 14)
+    @to_datetime = @dl_time.to_datetime(base)
+    
+    assert_equal DateTime, @to_datetime.class
+    assert_equal DateTime.new(1990, 11, 10, 13, 37, 42), @to_datetime
+  end
+
+
+  def test_to_datetime_with_date_base
+    base = Date.new(1990, 11, 10)
+    @to_datetime = @dl_time.to_datetime(base)
+    
+    assert_equal DateTime, @to_datetime.class
+    assert_equal DateTime.new(1990, 11, 10, 13, 37, 42), @to_datetime
+  end
+
+
+  def test_to_datetime_with_different_bases_should_change
+    @to_datetime = @dl_time.to_datetime
+    now = DateTime.now
+    expected = DateTime.new(now.year, now.month, now.day, 13, 37, 42, now.utc_offset)
+
+    assert_equal DateTime, @to_datetime.class
+    assert_equal expected, @to_datetime
+
+
+    base = DateTime.new(1990, 11, 10, 12, 13, 14)
+    @to_datetime = @dl_time.to_datetime(base)
+    
+    assert_equal DateTime, @to_datetime.class
+    assert_equal DateTime.new(1990, 11, 10, 13, 37, 42), @to_datetime
+  end
+
+=begin
+=end
 
   def test_to_s
     assert_equal "13:37:42", @dl_time.to_s


### PR DESCRIPTION
Add to_datetime function to get DateTime objects.
The implementation is similar to the implementation of to_time.

The test needs a little patch of DateTime to support DateTime#utc_offset.
