### PR TITLE
Added class methods for the '+' and '-' arithmetic operators.

### DIFF
--- a/lib/dateless_time.rb
+++ b/lib/dateless_time.rb
@@ -105,6 +105,28 @@ class DatelessTime
   end
 
 
+  def -(other)
+    # other.class.is_a? Numeric (seconds)
+    # return type is DatelessTime
+    #
+    # other.class.is_a? DatelessTime
+    # return type is Numeric
+    if other.is_a? Numeric
+      DatelessTime.new(calculate_seconds_since_midnight - other)
+    elsif other.is_a? DatelessTime
+      Float.new((calculate_seconds_since_midnight - other.calculate_seconds_since_midnight)).abs
+    else
+      raise TypeError
+    end
+  end
+
+
+  def +(other)
+    # Can only add numerics (in seconds) to time.
+    raise TypeError if other.is_a?(DatelessTime)
+    DatelessTime.new(calculate_seconds_since_midnight + other)
+  end
+
 
 private
 

--- a/test/comparable_test.rb
+++ b/test/comparable_test.rb
@@ -119,4 +119,30 @@ class ComparableTest < Minitest::Test
     assert_equal [@t3, @t2, @t1, @t4], @array.sort
   end
 
+  def test_add
+    @t1 = DatelessTime.new "8:30:00"
+    @t2 = DatelessTime.new "9:15:00"
+    @t3 = DatelessTime.new "0"
+    @correct_time = DatelessTime.new "9:30:00"
+
+    assert_equal @correct_time, @t1+3600
+    assert_equal @correct_time, @t2+900
+    assert_equal @correct_time, @t3+((60*60*9)+(60*30))
+    refute_equal @t1, @t2+(4500)
+  end
+
+
+  def test_sub
+    @t1 = DatelessTime.new "8:30:00"
+    @t2 = DatelessTime.new "9:15:00"
+    @t3 = DatelessTime.new "0"
+
+    assert_equal DatelessTime.new([2]), @t1-23400
+    assert_equal @t3, @t2-33300
+    refute_equal @t1, @t2-t1
+
+    assert_equal (45*60), @t2-@t1
+    assert_equal @t1, @t3-@t1
+  end
+
 end


### PR DESCRIPTION
I made them consistent with Ruby's Time class '**+**' and '**-**' operators I believe. 

`+` method allows addition to a DatelessTime object with a Numeric only (seconds), and returns a DatelessTime object. 
`-` method allows subtraction from a DatelessTime object from a Numeric (seconds) and returns a DatelessTime object, or from another DatelessTime object, which returns a Float representing the difference in time in seconds.

I used your `calculate_seconds_since_midnight` method in both methods.

I wrote a few tests in the comparable_tests file showing the use.