### PR TITLE
Added '+' and '-' arithmetic operators. (EDIT: fixed errors)

### DIFF
--- a/lib/dateless_time.rb
+++ b/lib/dateless_time.rb
@@ -114,7 +114,8 @@ class DatelessTime
     if other.is_a? Numeric
       DatelessTime.new(calculate_seconds_since_midnight - other)
     elsif other.is_a? DatelessTime
-      Float.new((calculate_seconds_since_midnight - other.calculate_seconds_since_midnight)).abs
+      otherSeconds = (other.hour * 60 * 60) + (other.min * 60) + other.sec
+      (calculate_seconds_since_midnight - otherSeconds).abs
     else
       raise TypeError
     end

--- a/lib/dateless_time.rb
+++ b/lib/dateless_time.rb
@@ -100,22 +100,20 @@ class DatelessTime
 
 
   def <=>(other)
-    raise TypeError unless other.is_a?(DatelessTime)
+    raise TypeError unless other.is_a? DatelessTime
     to_i <=> other.to_i
   end
 
 
   def -(other)
-    # other.class.is_a? Numeric (seconds)
-    # return type is DatelessTime
-    #
-    # other.class.is_a? DatelessTime
-    # return type is Numeric
-    if other.is_a? Numeric
-      DatelessTime.new(calculate_seconds_since_midnight - other)
+    if other.is_a? Integer
+      # Return DatelessTime object
+      raise DatelessTime::TimeOutOfRangeError if other > to_i # Would be negative
+      DatelessTime.new(to_i - other)
     elsif other.is_a? DatelessTime
-      otherSeconds = (other.hour * 60 * 60) + (other.min * 60) + other.sec
-      (calculate_seconds_since_midnight - otherSeconds).abs
+      # Return Integer
+      raise DatelessTime::TimeOutOfRangeError if other > self
+      to_i - other.to_i
     else
       raise TypeError
     end
@@ -124,8 +122,9 @@ class DatelessTime
 
   def +(other)
     # Can only add numerics (in seconds) to time.
-    raise TypeError if other.is_a?(DatelessTime)
-    DatelessTime.new(calculate_seconds_since_midnight + other)
+    raise TypeError unless other.is_a? Integer
+    raise DatelessTime::TimeOutOfRangeError if (seconds_since_midnight.to_i + other) > SECONDS_IN_24_HOURS
+    DatelessTime.new(seconds_since_midnight.to_i + other)
   end
 
 

--- a/lib/dateless_time.rb
+++ b/lib/dateless_time.rb
@@ -105,6 +105,28 @@ class DatelessTime
   end
 
 
+  def -(other)
+    # other.class.is_a? Numeric (seconds)
+    # return type is DatelessTime
+    #
+    # other.class.is_a? DatelessTime
+    # return type is Numeric
+    if other.is_a? Numeric
+      DatelessTime.new(calculate_seconds_since_midnight - other)
+    elsif other.is_a? DatelessTime
+      Float.new((calculate_seconds_since_midnight - other.calculate_seconds_since_midnight)).abs
+    else
+      raise TypeError
+    end
+  end
+
+
+  def +(other)
+    # Can only add numerics (in seconds) to time.
+    raise TypeError if other.is_a?(DatelessTime)
+    DatelessTime.new(calculate_seconds_since_midnight + other)
+  end
+
 
 private
 

--- a/test/comparable_test.rb
+++ b/test/comparable_test.rb
@@ -125,10 +125,10 @@ class ComparableTest < Minitest::Test
     @t3 = DatelessTime.new "0"
     @correct_time = DatelessTime.new "9:30:00"
 
-    assert_equal @correct_time, @t1+3600
-    assert_equal @correct_time, @t2+900
-    assert_equal @correct_time, @t3+((60*60*9)+(60*30))
-    refute_equal @t1, @t2+(4500)
+    assert_equal @correct_time, @t1 + 3600
+    assert_equal @correct_time, @t2 + 900
+    assert_equal @correct_time, @t3 + ((60 * 60 * 9)+(60 * 30))
+    refute_equal @t1, @t2 + 4500
   end
 
 
@@ -137,12 +137,12 @@ class ComparableTest < Minitest::Test
     @t2 = DatelessTime.new "9:15:00"
     @t3 = DatelessTime.new "0"
 
-    assert_equal DatelessTime.new([2]), @t1-23400
-    assert_equal @t3, @t2-33300
-    refute_equal @t1, @t2-t1
+    assert_equal DatelessTime.new([2]), @t1 - 23400
+    assert_equal @t3, @t2 - 33300
+    refute_equal @t1, @t2 - 0
 
-    assert_equal (45*60), @t2-@t1
-    assert_equal @t1, @t3-@t1
+    assert_equal (45 * 60), @t2 - @t1
+    assert_equal (8 * 60 * 60) + (30 * 60), @t3 - @t1
   end
 
 end

--- a/test/comparable_test.rb
+++ b/test/comparable_test.rb
@@ -128,6 +128,7 @@ class ComparableTest < Minitest::Test
     assert_equal @correct_time, @t1 + 3600
     assert_equal @correct_time, @t2 + 900
     assert_equal @correct_time, @t3 + ((60 * 60 * 9)+(60 * 30))
+    assert_raises(DatelessTime::TimeOutOfRangeError) { @t1 + 86400 }
     refute_equal @t1, @t2 + 4500
   end
 
@@ -142,7 +143,7 @@ class ComparableTest < Minitest::Test
     refute_equal @t1, @t2 - 0
 
     assert_equal (45 * 60), @t2 - @t1
-    assert_equal (8 * 60 * 60) + (30 * 60), @t3 - @t1
+    assert_raises(DatelessTime::TimeOutOfRangeError) { @t3 - @t1 }
   end
 
 end

--- a/test/comparable_test.rb
+++ b/test/comparable_test.rb
@@ -119,4 +119,30 @@ class ComparableTest < Minitest::Test
     assert_equal [@t3, @t2, @t1, @t4], @array.sort
   end
 
+  def test_add
+    @t1 = DatelessTime.new "8:30:00"
+    @t2 = DatelessTime.new "9:15:00"
+    @t3 = DatelessTime.new "0"
+    @correct_time = DatelessTime.new "9:30:00"
+
+    assert_equal @correct_time, @t1+3600
+    assert_equal @correct_time, @t2+900
+    assert_equal @correct_time, @t3+((60*60*9)+(60*30))
+    refute_equal @t1, @t2+(4500)
+  end
+
+
+  def test_sub
+    @t1 = DatelessTime.new "8:30:00"
+    @t2 = DatelessTime.new "9:15:00"
+    @t3 = DatelessTime.new "0"
+
+    assert_equal DatelessTime.new([2]), @t1-23400
+    assert_equal @t3, @t2-33300
+    refute_equal @t1, @t2-t1
+
+    assert_equal (45*60), @t2-@t1
+    assert_equal @t1, @t3-@t1
+  end
+
 end


### PR DESCRIPTION
I made them consistent with Ruby's Time class '**+**' and '**-**' operators I believe.

`+` method allows addition to a DatelessTime object with a Numeric only (seconds), and returns a DatelessTime object.
`-` method allows subtraction from a DatelessTime object from a Numeric (seconds) and returns a DatelessTime object, or from another DatelessTime object, which returns a Float representing the difference in time in seconds.

I used your `calculate_seconds_since_midnight` method in both methods to quickly convert to seconds.

I wrote a few tests in the comparable_tests file showing the use.